### PR TITLE
Use an existing session object in FuturesSesion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,15 @@ As a shortcut in case of just increasing workers number you can pass
     from requests_futures.sessions import FuturesSession
     session = FuturesSession(max_workers=10)
 
+FutureSession will use an existing session object if supplied:
+
+.. code-block:: python
+
+    from requests import session
+    from requests_futures.sessions import FuturesSession
+    my_session = session()
+    future_session = FuturesSession(session=my_session)
+
 That's it. The api of requests.Session is preserved without any modifications
 beyond returning a Future rather than Response. As with all futures exceptions
 are shifted (thrown) to the future.result() call so try/except blocks should be

--- a/requests_futures/sessions.py
+++ b/requests_futures/sessions.py
@@ -27,7 +27,8 @@ from requests.adapters import DEFAULT_POOLSIZE, HTTPAdapter
 
 class FuturesSession(Session):
 
-    def __init__(self, executor=None, max_workers=2, *args, **kwargs):
+    def __init__(self, executor=None, max_workers=2, session=None, *args,
+                 **kwargs):
         """Creates a FuturesSession
 
         Notes
@@ -50,6 +51,7 @@ class FuturesSession(Session):
                 self.mount('http://', HTTPAdapter(**adapter_kwargs))
 
         self.executor = executor
+        self.session = session
 
     def request(self, *args, **kwargs):
         """Maintains the existing api for Session.request.
@@ -60,7 +62,10 @@ class FuturesSession(Session):
         response in the background, e.g. call resp.json() so that json parsing
         happens in the background thread.
         """
-        func = sup = super(FuturesSession, self).request
+        if self.session:
+            func = sup = self.session.request
+        else:
+            func = sup = super(FuturesSession, self).request
 
         background_callback = kwargs.pop('background_callback', None)
         if background_callback:

--- a/test_requests_futures.py
+++ b/test_requests_futures.py
@@ -4,7 +4,7 @@
 """Tests for Requests."""
 
 from concurrent.futures import Future
-from requests import Response
+from requests import Response, session
 from os import environ
 from requests_futures.sessions import FuturesSession
 from unittest import TestCase, main
@@ -53,6 +53,18 @@ class RequestsTestCase(TestCase):
         with self.assertRaises(Exception) as cm:
             resp = future.result()
         self.assertEqual('boom', cm.exception.args[0])
+
+    def test_supplied_session(self):
+        """ Tests the `session` keyword argument. """
+        requests_session = session()
+        requests_session.headers['Foo'] = 'bar'
+        sess = FuturesSession(session=requests_session)
+        future = sess.get(httpbin('headers'))
+        self.assertIsInstance(future, Future)
+        resp = future.result()
+        self.assertIsInstance(resp, Response)
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(resp.json()['headers']['Foo'], 'bar')
 
     def test_max_workers(self):
         """ Tests the `max_workers` shortcut. """


### PR DESCRIPTION
Add a keyword argument to FuturesSession which will allow an instance to
use an existing session object rather than deferring to its superclass
when making a request.

Resolves #27.