### PR TITLE
Feature: support ProcessPoolExecutor (Python >= 3.3 required)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,68 @@ for a simple example take json parsing.
     pprint(response.data)
 
 
+
+Using ProcessPoolExecutor
+=========================
+
+Similarly to `ThreadPoolExecutor`, it is possible to use an instance of
+`ProcessPoolExecutor`. As the name suggest, the requests will be executed
+concurrently in separate processes rather than threads.
+
+.. code-block:: python
+
+    from concurrent.futures import ProcessPoolExecutor
+    from requests_futures.sessions import FuturesSession
+
+    session = FuturesSession(executor=ProcessPoolExecutor(max_workers=10))
+    # ... use as before
+
+.. HINT::
+    Using the `ProcessPoolExecutor` is useful, in cases where memory
+    usage per request is very high (large response) and cycling the interpretor
+    is required to release memory back to OS.
+
+A base requirement of using `ProcessPoolExecutor` is that the `Session.request`,
+`FutureSession` and (the optional) `background_callback` all be pickle-able.
+
+This means that only Python 3.5 is fully supported, while Python versions
+3.4 and above REQUIRE an existing `requests.Session` instance to be passed
+when initializing `FutureSession`. Python 2.X and < 3.4 are currently not
+supported.
+
+.. code-block:: python
+    
+    # Using python 3.4
+    from concurrent.futures import ProcessPoolExecutor
+    from requests import Session
+    from requests_futures.sessions import FuturesSession
+
+    session = FuturesSession(executor=ProcessPoolExecutor(max_workers=10),
+                             session=Session())
+    # ... use as before
+
+In case pickling fails, an exception is raised pointing to this documentation.
+
+.. code-block:: python
+    
+    # Using python 2.7
+    from concurrent.futures import ProcessPoolExecutor
+    from requests import Session
+    from requests_futures.sessions import FuturesSession
+
+    session = FuturesSession(executor=ProcessPoolExecutor(max_workers=10),
+                             session=Session())
+    Traceback (most recent call last):
+    ...
+    RuntimeError: Cannot pickle function. Refer to documentation: https://github.com/ross/requests-futures/#using-processpoolexecutor
+
+.. IMPORTANT::
+  * Python >= 3.4 required
+  * A session instance is required when using Python < 3.5
+  * If sub-classing `FuturesSession` it must be importable (module global)
+  * If using `background_callback` it too must be importable (module global)
+
+
 Installation
 ============
 

--- a/test_requests_futures.py
+++ b/test_requests_futures.py
@@ -4,10 +4,12 @@
 """Tests for Requests."""
 
 from concurrent.futures import Future
-from requests import Response, session
 from os import environ
+import unittest
+import sys
+
+from requests import Response, session
 from requests_futures.sessions import FuturesSession
-from unittest import TestCase, main
 
 HTTPBIN = environ.get('HTTPBIN_URL', 'http://httpbin.org/')
 
@@ -17,7 +19,7 @@ def httpbin(*suffix):
     return HTTPBIN + '/'.join(suffix)
 
 
-class RequestsTestCase(TestCase):
+class RequestsTestCase(unittest.TestCase):
 
     def test_futures_session(self):
         # basic futures get
@@ -117,5 +119,135 @@ class RequestsTestCase(TestCase):
         self.assertTrue(passout._exit_called)
 
 
+# << test process pool executor >>
+# see discussion https://github.com/ross/requests-futures/issues/11
+def global_cb_modify_response(s, r):
+    """ add the parsed json data to the response """
+    assert s, FuturesSession
+    assert r, Response
+    r.data = r.json()
+    r.__attrs__.append('data')  # required for pickling new attribute
+
+
+def global_cb_return_result(s, r):
+    """ simply return parsed json data """
+    assert s, FuturesSession
+    assert r, Response
+    return r.json()
+
+
+def global_rasing_cb(s, r):
+    raise Exception('boom')
+
+
+# pickling instance method supported only from here
+unsupported_platform = sys.version_info < (3, 3, 5)
+session_required = sys.version_info < (3, 5,)
+
+
+@unittest.skipIf(unsupported_platform, 'not supported in python < 3.3.5')
+class RequestsProcessPoolTestCase(unittest.TestCase):
+
+    def setUp(self):
+        from concurrent.futures import ProcessPoolExecutor
+        self.proc_executor = ProcessPoolExecutor(max_workers=2)
+        self.session = session()
+
+    @unittest.skipIf(session_required, 'not supported in python < 3.5')
+    def test_futures_session(self):
+        self._assert_futures_session()
+
+    def test_futures_existing_session(self):
+        self.session.headers['Foo'] = 'bar'
+        self._assert_futures_session(session=self.session)
+
+    def _assert_futures_session(self, session=None):
+        # basic futures get
+        if session:
+            sess = FuturesSession(executor=self.proc_executor, session=session)
+        else:
+            sess = FuturesSession(executor=self.proc_executor)
+
+        future = sess.get(httpbin('get'))
+        self.assertIsInstance(future, Future)
+        resp = future.result()
+        self.assertIsInstance(resp, Response)
+        self.assertEqual(200, resp.status_code)
+
+        # non-200, 404
+        future = sess.get(httpbin('status/404'))
+        resp = future.result()
+        self.assertEqual(404, resp.status_code)
+
+        future = sess.get(httpbin('get'),
+                          background_callback=global_cb_modify_response)
+        # this should block until complete
+        resp = future.result()
+        if session:
+            self.assertEqual(resp.json()['headers']['Foo'], 'bar')
+        self.assertEqual(200, resp.status_code)
+        # make sure the callback was invoked
+        self.assertTrue(hasattr(resp, 'data'))
+
+        future = sess.get(httpbin('get'),
+                          background_callback=global_cb_return_result)
+        # this should block until complete
+        resp = future.result()
+        # make sure the callback was invoked
+        self.assertIsInstance(resp, dict)
+
+        future = sess.get(httpbin('get'), background_callback=global_rasing_cb)
+        with self.assertRaises(Exception) as cm:
+            resp = future.result()
+        self.assertEqual('boom', cm.exception.args[0])
+
+        # Tests for the ability to cleanly handle redirects
+        future = sess.get(httpbin('redirect-to?url=get'))
+        self.assertIsInstance(future, Future)
+        resp = future.result()
+        self.assertIsInstance(resp, Response)
+        self.assertEqual(200, resp.status_code)
+
+        future = sess.get(httpbin('redirect-to?url=status/404'))
+        resp = future.result()
+        self.assertEqual(404, resp.status_code)
+
+    @unittest.skipIf(session_required, 'not supported in python < 3.5')
+    def test_context(self):
+        self._assert_context()
+
+    def test_context_with_session(self):
+        self._assert_context(session=self.session)
+
+    def _assert_context(self, session=None):
+        if session:
+            helper_instance = TopLevelContextHelper(executor=self.proc_executor,
+                                                    session=self.session)
+        else:
+            helper_instance = TopLevelContextHelper(executor=self.proc_executor)
+        passout = None
+        with helper_instance as sess:
+            passout = sess
+            future = sess.get(httpbin('get'))
+            self.assertIsInstance(future, Future)
+            resp = future.result()
+            self.assertIsInstance(resp, Response)
+            self.assertEqual(200, resp.status_code)
+
+        self.assertTrue(passout._exit_called)
+
+
+class TopLevelContextHelper(FuturesSession):
+    def __init__(self, *args, **kwargs):
+        super(TopLevelContextHelper, self).__init__(
+            *args, **kwargs)
+        self._exit_called = False
+
+    def __exit__(self, *args, **kwargs):
+        self._exit_called = True
+        return super(TopLevelContextHelper, self).__exit__(
+            *args, **kwargs)
+
+
 if __name__ == '__main__':
-    main()
+    unittest.main()


### PR DESCRIPTION
## Change Summary

* include tests, some of which are skipped if on unsupported python version
* use `functools.partial` instead of directly wrapping the `request` method,
  regardless of executor used - avoid code branching
* use `functools.partial(Session.request, self)` instead of
  `super(FuturesSession, self).request` for pickling, again no code branching

## Notes / Limitations

* **Python version 3.4** (actually >= 3.3.5) is required in order for us to pickle methods, [due to python issue 9276](https://bugs.python.org/issue9276). Though we may be able to [use `copy_reg` to add this support to Python 2](http://stackoverflow.com/a/25161919/484127).
* **Python 3.5** is required to "create a session on demand", with lower versions an existing session is required. Probably due to one of the numerous `pickle` related issues [fixed in 3.5](https://docs.python.org/3/whatsnew/changelog.html).
* Adding custom attributes to the response object in the callback is supported in `ProcessPoolExecutor` but only when the callback also modifies `__attrs__` so it gets pickled and sent to parent process (see an example for that in the tests).
* As mentioned, the `background_callback` MUST be a top-level (or otherwise importable) object. Additionally, since an instance of `FuturesSession` is passed to the callback (as `self`), it too must be importable, otherwise `pickle` will complain.

## Conclusions

This relatively simple implementation fixes issue #11, however due to numerous caveats, I'd suggest we recommend it be used in Python 3.5 and above and explain the limitation of earlier versions. If earlier versions (like Python 2) are really required by someone they may need to implement a manual fix to the `pickle` implementation (e.g using `copy_reg`).

Personally, this PR solves my issue but I have yet to test it on production, hopefully, will do so in the near future.