### PR TITLE
Add usage documentation for __exit__()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,24 @@ beyond returning a Future rather than Response. As with all futures exceptions
 are shifted (thrown) to the future.result() call so try/except blocks should be
 moved there.
 
+Canceling queued requests (a.k.a cleaning up after yourself)
+=========================
+
+If you know that you won't be needing any additional responses from futures that 
+haven't yet resolved, it's a good idea to cancel those requests. You can do this 
+by using the session as a context manager:
+
+.. code-block:: python
+    from requests_futures.sessions import FuturesSession
+    with FuturesSession(max_workers=1) as session:
+        future = session.get('https://httpbin.org/get')
+        future2 = session.get('https://httpbin.org/delay/10')
+        future3 = session.get('https://httpbin.org/delay/10')
+        response = future.result()
+        
+In this example, the second or third request will be skipped, saving time and 
+resources that would otherwise be wasted.
+
 Working in the Background
 =========================
 


### PR DESCRIPTION
If, for some reason, you queue a gazillion requests with FuturesSession and then throw away those objects, the requests are still made and the calling process waits for them to finish. (I discovered this while testing error handling in a Django TestCase)

Using the session as a contextmanager will avoid this wastefulness, so I think it should be documented.