### PR TITLE
remove py32 support(for ci)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.2
   - 3.3
   - 3.4
   - 3.5

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py32, py33, py34, py35, pypy, style
+envlist = py27, py33, py34, py35, pypy, style
 
 [testenv]
 setenv =


### PR DESCRIPTION
Python32 is no longer support by requests,
See https://github.com/requests/requests/issues/3479