### PR TITLE
Increase max_workers default value to 8

### DIFF
--- a/requests_futures/sessions.py
+++ b/requests_futures/sessions.py
@@ -39,7 +39,7 @@ PICKLE_ERROR = ('Cannot pickle function. Refer to documentation: https://'
 
 class FuturesSession(Session):
 
-    def __init__(self, executor=None, max_workers=2, session=None,
+    def __init__(self, executor=None, max_workers=8, session=None,
                  adapter_kwargs=None, *args, **kwargs):
         """Creates a FuturesSession
 

--- a/test_requests_futures.py
+++ b/test_requests_futures.py
@@ -77,7 +77,7 @@ class RequestsTestCase(TestCase):
         """ Tests the `max_workers` shortcut. """
         from concurrent.futures import ThreadPoolExecutor
         session = FuturesSession()
-        self.assertEqual(session.executor._max_workers, 2)
+        self.assertEqual(session.executor._max_workers, 8)
         session = FuturesSession(max_workers=5)
         self.assertEqual(session.executor._max_workers, 5)
         session = FuturesSession(executor=ThreadPoolExecutor(max_workers=10))


### PR DESCRIPTION
This closes #66 and increases max_workers to a more useful value for most concurrent use cases