### PR TITLE
Give higher level methods correct return type hint

### DIFF
--- a/requests_futures/sessions.py
+++ b/requests_futures/sessions.py
@@ -109,3 +109,44 @@ class FuturesSession(Session):
         if self._owned_executor:
             self.executor.shutdown()
 
+    def get(self, url, **kwargs):
+        """
+        :rtype : concurrent.futures.Future
+        """
+        return super(FuturesSession, self).get(url, **kwargs)
+
+    def options(self, url, **kwargs):
+        """
+        :rtype : concurrent.futures.Future
+        """
+        return super(FuturesSession, self).options(url, **kwargs)
+
+    def head(self, url, **kwargs):
+        """
+        :rtype : concurrent.futures.Future
+        """
+        return super(FuturesSession, self).head(url, **kwargs)
+
+    def post(self, url, data=None, json=None, **kwargs):
+        """
+        :rtype : concurrent.futures.Future
+        """
+        return super(FuturesSession, self).post(url, data=data, json=json, **kwargs)
+
+    def put(self, url, data=None, **kwargs):
+        """
+        :rtype : concurrent.futures.Future
+        """
+        return super(FuturesSession, self).put(url, data=data, **kwargs)
+
+    def patch(self, url, data=None, **kwargs):
+        """
+        :rtype : concurrent.futures.Future
+        """
+        return super(FuturesSession, self).patch(url, data=data, **kwargs)
+
+    def delete(self, url, **kwargs):
+        """
+        :rtype : concurrent.futures.Future
+        """
+        return super(FuturesSession, self).delete(url, **kwargs)

--- a/requests_futures/sessions.py
+++ b/requests_futures/sessions.py
@@ -110,43 +110,72 @@ class FuturesSession(Session):
             self.executor.shutdown()
 
     def get(self, url, **kwargs):
-        """
+        r"""
+        Sends a GET request. Returns :class:`Future` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype : concurrent.futures.Future
         """
         return super(FuturesSession, self).get(url, **kwargs)
 
     def options(self, url, **kwargs):
-        """
+        r"""Sends a OPTIONS request. Returns :class:`Future` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype : concurrent.futures.Future
         """
         return super(FuturesSession, self).options(url, **kwargs)
 
     def head(self, url, **kwargs):
-        """
+        r"""Sends a HEAD request. Returns :class:`Future` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype : concurrent.futures.Future
         """
         return super(FuturesSession, self).head(url, **kwargs)
 
     def post(self, url, data=None, json=None, **kwargs):
-        """
+        r"""Sends a POST request. Returns :class:`Future` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param json: (optional) json to send in the body of the :class:`Request`.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype : concurrent.futures.Future
         """
         return super(FuturesSession, self).post(url, data=data, json=json, **kwargs)
 
     def put(self, url, data=None, **kwargs):
-        """
+        r"""Sends a PUT request. Returns :class:`Future` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype : concurrent.futures.Future
         """
         return super(FuturesSession, self).put(url, data=data, **kwargs)
 
     def patch(self, url, data=None, **kwargs):
-        """
+        r"""Sends a PATCH request. Returns :class:`Future` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype : concurrent.futures.Future
         """
         return super(FuturesSession, self).patch(url, data=data, **kwargs)
 
     def delete(self, url, **kwargs):
-        """
+        r"""Sends a DELETE request. Returns :class:`Future` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype : concurrent.futures.Future
         """
         return super(FuturesSession, self).delete(url, **kwargs)


### PR DESCRIPTION
Higher level methods, e.g. Session.get actually returns Future instead of Response, the docstring should be updated accordingly to prevent confusing IDEs. 