### PR TITLE
Use Environment Markers instead of version_info.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,9 @@ packages = [
 ]
 
 requires = [
-    'requests>=1.2.0'
+    'requests>=1.2.0',
+    "futures>=2.1.3; python_version<'3.2'"
 ]
-
-if sys.version_info < (3, 2):
-    requires.append('futures>=2.1.3')
 
 setup(
     name='requests-futures',


### PR DESCRIPTION
PEP-508 recommends Environment markers for better compatibility with modern build tools and dependency managers such as Poetry.

https://www.python.org/dev/peps/pep-0508/#environment-markers

E.g., See also:

sdispater/poetry#844
sdispater/poetry#881