### PR TITLE
docs: fix simple typo, interpretor -> interpreter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -271,7 +271,7 @@ concurrently in separate processes rather than threads.
 
 .. HINT::
     Using the `ProcessPoolExecutor` is useful, in cases where memory
-    usage per request is very high (large response) and cycling the interpretor
+    usage per request is very high (large response) and cycling the interpreter
     is required to release memory back to OS.
 
 A base requirement of using `ProcessPoolExecutor` is that the `Session.request`,


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `interpreter` rather than `interpretor`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md