### PR TITLE
Document support for py3.6, 3.7, and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.4
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 env: HTTPBIN_URL=https://nghttp2.org/httpbin/
 script: python test_requests_futures.py
 install: pip install -r requirements-python-2.7.txt

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     options={'bdist_wheel': {'universal': True}},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, pypy, style
+envlist = py27, py34, py35, py36, py37, py38, pypy, style
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, pypy, style
+envlist = py27, py36, py37, py38, pypy, style
 
 [testenv]
 setenv =


### PR DESCRIPTION
The `futures` functionality has not changed in the newer python versions, code runs successfully and tests pass in these versions. 