### PR TITLE
pytest mark network, pyproject.toml, isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ skip-magic-trailing-comma=true
 
 [tool.isort]
 profile = "black"
-known_first_party="octodns"
+known_first_party="requests_futures"
 line_length=80
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.black]
+line-length=80
+skip-string-normalization=true
+skip-magic-trailing-comma=true
+
+[tool.isort]
+profile = "black"
+known_first_party="octodns"
+line_length=80
+
+[tool.pytest.ini_options]
+markers = [
+    "network: tests that require network connectivity to pass"
+]
+pythonpath = "."

--- a/requests_futures/sessions.py
+++ b/requests_futures/sessions.py
@@ -19,10 +19,10 @@ releases of python.
     print(response.content)
 
 """
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from functools import partial
 from logging import getLogger
-from pickle import dumps, PickleError
+from pickle import PickleError, dumps
 
 from requests import Session
 from requests.adapters import DEFAULT_POOLSIZE, HTTPAdapter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ coverage==7.2.7
 docutils==0.20.1
 importlib-metadata==6.7.0
 iniconfig==2.0.0
+isort==5.12.0
 jaraco.classes==3.2.3
 keyring==23.13.1
 markdown-it-py==3.0.0

--- a/script/format
+++ b/script/format
@@ -6,4 +6,5 @@ SOURCES=$(find *.py requests_futures tests -name "*.py")
 
 . env/bin/activate
 
-black --line-length=80 --skip-string-normalization --skip-magic-trailing-comma "$@" $SOURCES
+isort "$@" $SOURCES
+black "$@" $SOURCES

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         + (
             'black>=22.3.0',
             'build>=0.7.0',
+            'isort>=5.11.4',
             'pyflakes>=2.2.0',
             'readme_renderer[rst]>=26.0',
             'twine>=3.4.2',

--- a/tests/test_requests_futures.py
+++ b/tests/test_requests_futures.py
@@ -13,6 +13,7 @@ except ImportError:
     pypy_version_info = None
 from unittest import TestCase, main, skipIf
 import logging
+import pytest
 
 from requests import Response, session
 from requests.adapters import DEFAULT_POOLSIZE
@@ -30,6 +31,7 @@ def httpbin(*suffix):
 
 
 class RequestsTestCase(TestCase):
+    @pytest.mark.network
     def test_futures_session(self):
         # basic futures get
         sess = FuturesSession()
@@ -65,6 +67,7 @@ class RequestsTestCase(TestCase):
             resp = future.result()
         self.assertEqual('boom', cm.exception.args[0])
 
+    @pytest.mark.network
     def test_supplied_session(self):
         """Tests the `session` keyword argument."""
         requests_session = session()
@@ -112,6 +115,7 @@ class RequestsTestCase(TestCase):
         )
         self.assertEqual(session.get_adapter('http://')._pool_connections, 20)
 
+    @pytest.mark.network
     def test_redirect(self):
         """Tests for the ability to cleanly handle redirects."""
         sess = FuturesSession()
@@ -125,6 +129,7 @@ class RequestsTestCase(TestCase):
         resp = future.result()
         self.assertEqual(404, resp.status_code)
 
+    @pytest.mark.network
     def test_context(self):
         class FuturesSessionTestHelper(FuturesSession):
             def __init__(self, *args, **kwargs):
@@ -181,15 +186,18 @@ class RequestsProcessPoolTestCase(TestCase):
         self.proc_executor = ProcessPoolExecutor(max_workers=2)
         self.session = session()
 
+    @pytest.mark.network
     @skipIf(session_required, 'not supported in python < 3.5')
     def test_futures_session(self):
         self._assert_futures_session()
 
+    @pytest.mark.network
     @skipIf(not session_required, 'fully supported on python >= 3.5')
     def test_exception_raised(self):
         with self.assertRaises(RuntimeError):
             self._assert_futures_session()
 
+    @pytest.mark.network
     def test_futures_existing_session(self):
         self.session.headers['Foo'] = 'bar'
         self._assert_futures_session(session=self.session)
@@ -247,10 +255,12 @@ class RequestsProcessPoolTestCase(TestCase):
         resp = future.result()
         self.assertEqual(404, resp.status_code)
 
+    @pytest.mark.network
     @skipIf(session_required, 'not supported in python < 3.5')
     def test_context(self):
         self._assert_context()
 
+    @pytest.mark.network
     def test_context_with_session(self):
         self._assert_context(session=self.session)
 
@@ -285,6 +295,7 @@ class TopLevelContextHelper(FuturesSession):
 
 @skipIf(not unsupported_platform, 'Exception raised when unsupported')
 class ProcessPoolExceptionRaisedTestCase(TestCase):
+    @pytest.mark.network
     def test_exception_raised(self):
         executor = ProcessPoolExecutor(max_workers=2)
         sess = FuturesSession(executor=executor, session=session())

--- a/tests/test_requests_futures.py
+++ b/tests/test_requests_futures.py
@@ -11,12 +11,13 @@ try:
     from sys import pypy_version_info
 except ImportError:
     pypy_version_info = None
-from unittest import TestCase, main, skipIf
 import logging
-import pytest
+from unittest import TestCase, main, skipIf
 
+import pytest
 from requests import Response, session
 from requests.adapters import DEFAULT_POOLSIZE
+
 from requests_futures.sessions import FuturesSession
 
 HTTPBIN = environ.get('HTTPBIN_URL', 'https://nghttp2.org/httpbin/')


### PR DESCRIPTION
Add a new pytest mark for tests that use the network, to be used to skip test that hit the network and thus fail in environments w/o out as is the case in https://github.com/ross/requests-futures/issues/132.

Also adds a pyproject.toml, which registers the mark, and has some of my ~standard configs in it. Moves the black formatting details there and while I was messing with it all I went ahead and added isort into the mix.

/cc Fixes https://github.com/ross/requests-futures/issues/132 @kloczek