### PR TITLE
v1.0.1 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## v1.0.1 - 2023-06-19 - The first one in the CHANGELOG
+
+* Add pytest.mark.network to test cases
+* pyproject.toml config for black, isort, and pytest

--- a/requests_futures/__init__.py
+++ b/requests_futures/__init__.py
@@ -12,7 +12,7 @@ async requests HTTP library
 import logging
 
 __title__ = 'requests-futures'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __build__ = 0x000000
 __author__ = 'Ross McFarland'
 __license__ = 'Apache 2.0'


### PR DESCRIPTION
## v1.0.1 - 2023-06-19 - The first one in the CHANGELOG

* Add pytest.mark.network to test cases
* pyproject.toml config for black, isort, and pytest
